### PR TITLE
 Add swagger config for OpenAPI docs 

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,3 +13,9 @@ APP_BANNER=true
 #
 LOG_LEVEL=debug
 LOG_OUTPUT=dev
+
+#
+# Swagger
+#
+SWAGGER_ENABLED=true
+SWAGGER_ROUTE=/swagger

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "class-transformer": "^0.3.1",
-        "class-validator": "^0.12.2",
+        "class-transformer": "^0.4.0",
+        "class-validator": "^0.13.1",
+        "class-validator-jsonschema": "^3.1.0",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "dotenv": "^10.0.0",
@@ -21,6 +22,8 @@
         "multer": "^1.4.2",
         "reflect-metadata": "^0.1.13",
         "routing-controllers": "^0.9.0",
+        "routing-controllers-openapi": "^3.1.0",
+        "swagger-ui-express": "^4.3.0",
         "typedi": "^0.9.1",
         "uuid": "^8.3.2",
         "winston": "^3.3.3"
@@ -330,11 +333,6 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
       "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
       "dev": true
-    },
-    "node_modules/@types/validator": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.0.0.tgz",
-      "integrity": "sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.8.1",
@@ -931,19 +929,33 @@
       "dev": true
     },
     "node_modules/class-transformer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
-      "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
+      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA=="
     },
     "node_modules/class-validator": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.12.2.tgz",
-      "integrity": "sha512-TDzPzp8BmpsbPhQpccB3jMUE/3pK0TyqamrK0kcx+ZeFytMA+O6q87JZZGObHHnoo9GM8vl/JppIyKWeEA/EVw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
+      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
       "dependencies": {
-        "@types/validator": "13.0.0",
-        "google-libphonenumber": "^3.2.8",
-        "tslib": ">=1.9.0",
-        "validator": "13.0.0"
+        "libphonenumber-js": "^1.9.43",
+        "validator": "^13.7.0"
+      }
+    },
+    "node_modules/class-validator-jsonschema": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/class-validator-jsonschema/-/class-validator-jsonschema-3.1.0.tgz",
+      "integrity": "sha512-1If+ZK3ZKhJfA7QWi064RJ2oTadBqmBtVPRb4DyxIlWS2m2hc9kWHwoEfycOroVfTuANMZ4XOtp3JD27U5V95w==",
+      "dependencies": {
+        "lodash.groupby": "^4.6.0",
+        "lodash.merge": "^4.6.2",
+        "openapi3-ts": "^2.0.0",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.0.3"
+      },
+      "peerDependencies": {
+        "class-transformer": "^0.4.0",
+        "class-validator": "^0.13.1"
       }
     },
     "node_modules/cli-boxes": {
@@ -2161,14 +2173,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/google-libphonenumber": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.25.tgz",
-      "integrity": "sha512-M/b5mij5o2aGnbe+Id9O3847jBtP0baW61foFkevxBxbuV4LH9AcujjYLd2UVkUPKVdMpKyBZxfeNwdxqobQFQ==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -2794,11 +2798,30 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.9.44",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.44.tgz",
+      "integrity": "sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g=="
+    },
+    "node_modules/lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg="
     },
     "node_modules/logform": {
       "version": "2.3.0",
@@ -3194,6 +3217,14 @@
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
       "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=",
       "optional": true
+    },
+    "node_modules/openapi3-ts": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.1.tgz",
+      "integrity": "sha512-v6X3iwddhi276siej96jHGIqTx3wzVfMTmpGJEQDt7GPI7pI6sywItURLzpEci21SBRpPN/aOWSF5mVfFVNmcg==",
+      "dependencies": {
+        "yaml": "^1.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -3620,6 +3651,28 @@
         "class-validator": "^0.12.2"
       }
     },
+    "node_modules/routing-controllers-openapi": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/routing-controllers-openapi/-/routing-controllers-openapi-3.1.0.tgz",
+      "integrity": "sha512-FnTYnbNfsCN+vTDAc7rhCm5u0nLAH+p+UpbJXZT10cgo2t7xiZ23BrrzsR5nnqMGwe/iwsDUEEr8lxs6KarscQ==",
+      "dependencies": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.merge": "^4.6.2",
+        "lodash.startcase": "^4.4.0",
+        "openapi3-ts": "^2.0.1",
+        "path-to-regexp": "^2.2.1",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "routing-controllers": "^0.9.0"
+      }
+    },
+    "node_modules/routing-controllers-openapi/node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3885,6 +3938,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.1.3.tgz",
+      "integrity": "sha512-WvfPSfAAMlE/sKS6YkW47nX/hA7StmhYnAHc6wWCXNL0oclwLj6UXv0hQCkLnDgvebi0MEV40SJJpVjKUgH1IQ=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.3.0.tgz",
+      "integrity": "sha512-jN46SEEe9EoXa3ZgZoKgnSF6z0w3tnM1yqhO4Y+Q4iZVc8JOQB960EZpIAz6rNROrDApVDwcMHR0mhlnc/5Omw==",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.1.3"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
       }
     },
     "node_modules/template-url": {
@@ -4213,9 +4285,9 @@
       "dev": true
     },
     "node_modules/validator": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
-      "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -4432,6 +4504,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/ylru": {
       "version": "1.2.1",
@@ -4714,11 +4794,6 @@
       "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
       "dev": true
     },
-    "@types/validator": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.0.0.tgz",
-      "integrity": "sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw=="
-    },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.8.1.tgz",
@@ -4827,8 +4902,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -5142,19 +5216,29 @@
       "dev": true
     },
     "class-transformer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
-      "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
+      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA=="
     },
     "class-validator": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.12.2.tgz",
-      "integrity": "sha512-TDzPzp8BmpsbPhQpccB3jMUE/3pK0TyqamrK0kcx+ZeFytMA+O6q87JZZGObHHnoo9GM8vl/JppIyKWeEA/EVw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
+      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
       "requires": {
-        "@types/validator": "13.0.0",
-        "google-libphonenumber": "^3.2.8",
-        "tslib": ">=1.9.0",
-        "validator": "13.0.0"
+        "libphonenumber-js": "^1.9.43",
+        "validator": "^13.7.0"
+      }
+    },
+    "class-validator-jsonschema": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/class-validator-jsonschema/-/class-validator-jsonschema-3.1.0.tgz",
+      "integrity": "sha512-1If+ZK3ZKhJfA7QWi064RJ2oTadBqmBtVPRb4DyxIlWS2m2hc9kWHwoEfycOroVfTuANMZ4XOtp3JD27U5V95w==",
+      "requires": {
+        "lodash.groupby": "^4.6.0",
+        "lodash.merge": "^4.6.2",
+        "openapi3-ts": "^2.0.0",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.0.3"
       }
     },
     "cli-boxes": {
@@ -6117,11 +6201,6 @@
         "slash": "^3.0.0"
       }
     },
-    "google-libphonenumber": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.25.tgz",
-      "integrity": "sha512-M/b5mij5o2aGnbe+Id9O3847jBtP0baW61foFkevxBxbuV4LH9AcujjYLd2UVkUPKVdMpKyBZxfeNwdxqobQFQ=="
-    },
     "got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -6611,11 +6690,30 @@
         "type-check": "~0.4.0"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.9.44",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.44.tgz",
+      "integrity": "sha512-zhw8nUMJuQf7jG1dZfEOKKOS6M3QYIv3HnvB/vGohNd0QfxIQcObH3a6Y6s350H+9xgBeOXClOJkS0hJ0yvS3g=="
+    },
+    "lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
+    },
+    "lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg="
     },
     "logform": {
       "version": "2.3.0",
@@ -6916,6 +7014,14 @@
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
       "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=",
       "optional": true
+    },
+    "openapi3-ts": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.1.tgz",
+      "integrity": "sha512-v6X3iwddhi276siej96jHGIqTx3wzVfMTmpGJEQDt7GPI7pI6sywItURLzpEci21SBRpPN/aOWSF5mVfFVNmcg==",
+      "requires": {
+        "yaml": "^1.10.0"
+      }
     },
     "optionator": {
       "version": "0.9.1",
@@ -7225,6 +7331,27 @@
         "template-url": "^1.0.0"
       }
     },
+    "routing-controllers-openapi": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/routing-controllers-openapi/-/routing-controllers-openapi-3.1.0.tgz",
+      "integrity": "sha512-FnTYnbNfsCN+vTDAc7rhCm5u0nLAH+p+UpbJXZT10cgo2t7xiZ23BrrzsR5nnqMGwe/iwsDUEEr8lxs6KarscQ==",
+      "requires": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.merge": "^4.6.2",
+        "lodash.startcase": "^4.4.0",
+        "openapi3-ts": "^2.0.1",
+        "path-to-regexp": "^2.2.1",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
+        }
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7431,6 +7558,19 @@
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.1.3.tgz",
+      "integrity": "sha512-WvfPSfAAMlE/sKS6YkW47nX/hA7StmhYnAHc6wWCXNL0oclwLj6UXv0hQCkLnDgvebi0MEV40SJJpVjKUgH1IQ=="
+    },
+    "swagger-ui-express": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.3.0.tgz",
+      "integrity": "sha512-jN46SEEe9EoXa3ZgZoKgnSF6z0w3tnM1yqhO4Y+Q4iZVc8JOQB960EZpIAz6rNROrDApVDwcMHR0mhlnc/5Omw==",
+      "requires": {
+        "swagger-ui-dist": ">=4.1.3"
       }
     },
     "template-url": {
@@ -7676,9 +7816,9 @@
       "dev": true
     },
     "validator": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
-      "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA=="
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -7829,6 +7969,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "ylru": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
   },
   "homepage": "https://github.com/bhupesh-js/boilerplate-express-typescript#readme",
   "dependencies": {
-    "class-transformer": "^0.3.1",
-    "class-validator": "^0.12.2",
+    "class-transformer": "^0.4.0",
+    "class-validator": "^0.13.1",
+    "class-validator-jsonschema": "^3.1.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",
@@ -32,6 +33,8 @@
     "multer": "^1.4.2",
     "reflect-metadata": "^0.1.13",
     "routing-controllers": "^0.9.0",
+    "routing-controllers-openapi": "^3.1.0",
+    "swagger-ui-express": "^4.3.0",
     "typedi": "^0.9.1",
     "uuid": "^8.3.2",
     "winston": "^3.3.3"

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,9 +3,11 @@ import express from "express";
 import * as httpContext from "express-http-context";
 import { useContainer, useExpressServer } from "routing-controllers";
 import { Container } from "typedi";
+import * as swaggerUi from 'swagger-ui-express';
 import { Logger, configLogger } from "./core/logger";
 import { env } from './env';
 import { banner } from "./core/banner";
+import { swaggerConfig } from "./core/swagger";
 
 export class Application {
 	
@@ -35,6 +37,7 @@ export class Application {
 			interceptors: [__dirname +"/core/interceptors/*.ts"],
 		});
 		
+		this.server.use(env.swagger.route, swaggerUi.serve,  swaggerUi.setup(swaggerConfig()) )
 
 		const port = env.app.port;
 

--- a/src/controllers/book.controller.ts
+++ b/src/controllers/book.controller.ts
@@ -3,6 +3,7 @@ import {
 	Body,
 	Post
 } from "routing-controllers";
+import { ResponseSchema } from "routing-controllers-openapi";
 import { Service } from "typedi";
 import { BaseService } from "../core/base.service";
 import { BookPostRequest } from "./request";
@@ -18,6 +19,7 @@ export class BookController extends BaseService {
 	}
 
 	@Post("/book")
+	@ResponseSchema(BookResponse)
 	post( @Body({ required: true }) book: BookPostRequest ): BookResponse {
 		
         this._logger.info(`Post Book`);

--- a/src/controllers/response/book.response.ts
+++ b/src/controllers/response/book.response.ts
@@ -1,3 +1,5 @@
+import { IsString } from "class-validator";
+
 export class BookResponse{
 
     /**
@@ -6,6 +8,7 @@ export class BookResponse{
      * @type {string}
      * @memberof BookResponse
      */
+    @IsString()
     name:string;
 
 
@@ -15,5 +18,6 @@ export class BookResponse{
      * @type {string}
      * @memberof BookResponse
      */
+    @IsString()
     author:string
 }

--- a/src/core/banner.ts
+++ b/src/core/banner.ts
@@ -15,6 +15,10 @@ export function banner(log: Logger): void {
         log.info(`API Info     : ${route()}${env.app.routePrefix}`);
         log.info('-------------------------------------------------------');
         log.info('');
+        if (env.swagger.enabled) {
+            log.info(`Swagger      : ${route()}${env.swagger.route}`);
+            log.info('');
+        }
     } else {
         log.info(`Application is up and running.`);
     }

--- a/src/core/swagger/index.ts
+++ b/src/core/swagger/index.ts
@@ -1,0 +1,40 @@
+import { defaultMetadataStorage as classTransformerdefaultMetadataStorage } from "class-transformer/cjs/storage";
+import { validationMetadatasToSchemas } from 'class-validator-jsonschema';
+import { getMetadataArgsStorage } from 'routing-controllers';
+import { routingControllersToSpec } from 'routing-controllers-openapi';
+import { env } from '../../env';
+
+export const swaggerConfig = () => {
+    if (env.swagger.enabled) {
+
+        const schemas = validationMetadatasToSchemas({
+            classTransformerMetadataStorage:classTransformerdefaultMetadataStorage,
+            refPointerPrefix: '#/components/schemas/',
+        });
+
+        const swaggerFile = routingControllersToSpec(
+            getMetadataArgsStorage(),
+            {},
+            {
+                components: {
+                    schemas,
+                },
+            }
+        );
+
+        // Add npm infos to the swagger doc
+        swaggerFile.info = {
+            title: env.app.name,
+            description: env.app.description,
+            version: env.app.version,
+        };
+
+        swaggerFile.servers = [
+            {
+                url: `${env.app.schema}://${env.app.host}:${env.app.port}${env.app.routePrefix}`,
+            },
+        ];
+
+    return swaggerFile;
+    }
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -31,5 +31,8 @@ export const env = {
         level: getOsEnv('LOG_LEVEL'),
         output: getOsEnv('LOG_OUTPUT'),
     },
-   
+    swagger: {
+        enabled: toBool(getOsEnv('SWAGGER_ENABLED')),
+        route: getOsEnv('SWAGGER_ROUTE')
+    },
 };


### PR DESCRIPTION
# This PR includes the following changes:
- Added  Dependency :
   1. routing-controllers-openapi (Runtime OpenAPI v3 schema generation for routing-controllers.)
   2. swagger-ui-express ( auto-generated swagger-ui generated API docs from express)
   3. class-validator-jsonschema (Convert class-validator-decorated classes into OpenAPI-compatible JSON Schema)

- Updated Dependencies :  class-transformer and class-validator
- Added swagger config to the application
- Add response schema to showcase API response of book controller post method 


